### PR TITLE
Add xmonad/xmobar support to xcolor

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ WMs/DEs:
 * `i3`
 * `sway`
 * `bspwm`
+* `xmonad`
 
 Bars:
 
 * `polybar`
+* `xmobar` (assuming background and foreground is configured in launch script)
 
 This list will be updated as more configurations are tested.
 
@@ -253,3 +255,54 @@ c.colors.statusbar.url.success.https.fg = adjust(fg, 0.7)
 ### Shell Scripts
 
 Querying `.Xresources` variables can be done via `xrdb -query`. This can be further piped through applications such as `grep` and `sed` to extract the desired string.
+
+### <a name="haskell-xres-func"></a>XMonad/Haskell
+
+XResources can be configured using the function fromXres defined below:
+```
+import Data.Maybe
+import Data.Bifunctor
+import Data.List as DL
+import Data.Char as DC
+
+import System.IO
+import System.IO.Unsafe
+
+import XMonad
+import XMonad.Util.Run
+
+getFromXres :: String -> IO String
+getFromXres key = fromMaybe "" . findValue key <$> runProcessWithInput "xrdb" ["-query"] ""
+  where
+    findValue :: String -> String -> Maybe String
+    findValue xresKey xres =
+      snd <$> (
+                DL.find ((== xresKey) . fst)
+                $ catMaybes
+                $ splitAtColon
+                <$> lines xres
+              )
+
+    splitAtColon :: String -> Maybe (String, String)
+    splitAtColon str = splitAtTrimming str <$> (DL.elemIndex ':' str)
+
+    splitAtTrimming :: String -> Int -> (String, String)
+    splitAtTrimming str idx = bimap trim trim . (second tail) $ splitAt idx str
+
+    trim :: String -> String
+    trim = DL.dropWhileEnd (DC.isSpace) . DL.dropWhile (DC.isSpace)
+
+fromXres :: String -> String
+fromXres = unsafePerformIO . getFromXres
+```
+Credits to reddit user [/u/Joantmilev](https://www.reddit.com/user/Joantmilev/) from this [thread](https://www.reddit.com/r/xmonad/comments/kfwfma/how_to_pull_xresources_for_xmonad_config_settings/).
+
+### Xmobar
+
+Xmobar is traditionally use with the Xmonad WM. Within your xmonad.hs use the [`fromXres`](#haskell-xres-func) function as so:
+```
+    spawnPipe $ "xmobar " ++ 
+                "-B \"" ++ xmobarBgColor ++  "\" " ++ -- Set the background color
+                "-F \"" ++ xmobarFgColor ++  "\" " ++ -- Set the foreground color
+                -- ... continue configuration
+```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ WMs/DEs:
 Bars:
 
 * `polybar`
-* `xmobar` (assuming background and foreground is configured in launch script)
+* `xmobar` 
 
 This list will be updated as more configurations are tested.
 
@@ -301,6 +301,8 @@ Credits to reddit user [/u/Joantmilev](https://www.reddit.com/user/Joantmilev/) 
 
 Xmobar is traditionally use with the Xmonad WM. Within your xmonad.hs use the [`fromXres`](#haskell-xres-func) function as so:
 ```
+    xmobarBgColor = fromXres "*.color0"
+    xmobarFgColor = fromXres "*.color15"
     spawnPipe $ "xmobar " ++ 
                 "-B \"" ++ xmobarBgColor ++  "\" " ++ -- Set the background color
                 "-F \"" ++ xmobarFgColor ++  "\" " ++ -- Set the foreground color

--- a/xcolor
+++ b/xcolor
@@ -18,7 +18,7 @@ XRDB_CPP=${XRDB_CPP:-""}
 
 # Process list that xcolor will attempt to reload after a
 # theme change. Will only reload if alive prior to execution
-PROC_LIST="i3 bspwm sway polybar"
+PROC_LIST="i3 bspwm sway polybar xmonad"
 
 THEME=""
 SAVE_DEL_THEME=""
@@ -452,6 +452,10 @@ rel_bspwm() {
 
 rel_polybar() {
     pkill -USR1 -x polybar > /dev/null
+}
+
+rel_xmonad() {
+    xmonad --restart > /dev/null
 }
 
 rel_if_alive() {


### PR DESCRIPTION
Files Changed:
- README.md: documented xmonad/xmobar support
- xcolor: recompile then restart xmonad on color change

Testing:
- Ran xcolor -t to toggle themes. Colors in xmonad/xmobar changed as expected.