### PR TITLE
xcolor (v0.4.7): fix bug in update_spicetify

### DIFF
--- a/xcolor
+++ b/xcolor
@@ -2,7 +2,7 @@
 
 set -eCu
 
-VERSION="0.4.6"
+VERSION="0.4.7"
 
 OPTS=":hvlcrfs:d:t:"
 
@@ -418,7 +418,8 @@ make_cache_files() {
 
 update_spicetify() {
     if command -v spicetify > /dev/null; then
-        spicetify update > /dev/null
+        spicetify update > /dev/null ||
+            { echo "warning: spicetify update failed (check issue by running manually)"; }
     fi
 }
 


### PR DESCRIPTION
Due to `set -e` used in script, if `spicetify update` failed the script would stop. Not a huge fan of `set -e` anymore so wouldn't mind removing it, but for now just echoing a warning in an or cond if this fails.